### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ auditing, rate limiting, analytics, billing, logging, and monitoring.
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-service-control.svg
    :target: https://pypi.org/project/google-cloud-service-control/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-control.svg
@@ -84,4 +84,4 @@ Next Steps
    APIs that we cover.
 
 .. _Service Control Product documentation:  https://cloud.google.com/service-infrastructure/docs/service-control/getting-started
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.