### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "servicecontrol",
     "name_pretty": "Service Control API",
     "product_documentation": "https://cloud.google.com/service-infrastructure/docs/overview/",
-    "client_documentation": "https://googleapis.dev/python/servicecontrol/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/servicecontrol/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ auditing, rate limiting, analytics, billing, logging, and monitoring.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-service-control.svg
    :target: https://pypi.org/project/google-cloud-service-control/
 .. _Service Control: https://cloud.google.com/service-infrastructure/docs/overview/
-.. _Client Library Documentation: https://googleapis.dev/python/servicecontrol/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/servicecontrol/latest
 .. _Product Documentation:  https://cloud.google.com/service-infrastructure/docs/overview/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.